### PR TITLE
More ep2 map scripts

### DIFF
--- a/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_01.lua
+++ b/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_01.lua
@@ -96,6 +96,31 @@ function MAPSCRIPT:PostInit()
         ent:SetName("lambda_physbox_floor_door")
     end)
 
+
+    -- Remove all triggers when dropping into building and do it our way
+    local roomtrig1 = ents.FindByPos(Vector(-5486.51, 4505.71, -12), "trigger_once")
+    local roomtrig2 = ents.FindByPos(Vector(-5634, 4428, -72), "trigger_once")
+
+    local roomCP = GAMEMODE:CreateCheckpoint(Vector(-5689, 4510, -128), Angle(0, 0, 0))
+
+    local newRoomTrigger = ents.Create("trigger_once")
+    newRoomTrigger:SetupTrigger(Vector(-5624, 4508, -76), Angle(0, 0, 0), Vector(-168, -108, -42), Vector(168, 108, 42))
+    newRoomTrigger:SetName("AYAYAYAY")
+    newRoomTrigger:SetKeyValue("teamwait", "1")
+    newRoomTrigger:CloneOutputs(roomtrig1[1])
+    newRoomTrigger:Fire("AddOutput", "OnTrigger lcs.alyx.window,Start,,0,-1")
+    newRoomTrigger:Fire("AddOutput", "OnTrigger gate_control_lever,Unlock,,0,-1")
+    newRoomTrigger.OnTrigger = function(_, activator)
+        GAMEMODE:SetPlayerCheckpoint(roomCP, activator)
+    end
+
+    ents.WaitForEntityByName("gate_control_lever", function(ent)
+        ent:SetKeyValue("unlocked_sound", "13")
+    end)
+
+    roomtrig1[1]:Remove()
+    roomtrig2[1]:Remove()
+
     local openDoorTrigger = ents.Create("trigger_once")
     openDoorTrigger:SetName("lambda_trigger_open_door")
     openDoorTrigger:SetKeyValue("teamwait", "1")

--- a/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_02.lua
+++ b/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_02.lua
@@ -97,6 +97,42 @@ function MAPSCRIPT:PostInit()
             )
             ent:SetKeyValue("teamwait", "1")
         end)
+
+        -- point_viewcontrol entities need to have their spawnflags altered for the GMan scene to work properly
+        ents.WaitForEntityByName("pvc_black", function(ent)
+            local sf = bit.bor(4, 8, 128)
+            ent:SetKeyValue("spawnflags", sf)
+        end)
+
+        ents.WaitForEntityByName("pvc0", function(ent)
+            local sf = bit.bor(1, 4, 8, 128)
+            ent:SetKeyValue("spawnflags", sf)
+        end)
+
+        ents.WaitForEntityByName("pvc1", function(ent)
+            local sf = bit.bor(4, 8, 128)
+            ent:SetKeyValue("spawnflags", sf)
+        end)
+
+        ents.WaitForEntityByName("pvc2", function(ent)
+            local sf = bit.bor(4, 8, 16, 32, 128)
+            ent:SetKeyValue("spawnflags", sf)
+        end)
+
+        ents.WaitForEntityByName("pvc3", function(ent)
+            local sf = bit.bor(4, 8, 128)
+            ent:SetKeyValue("spawnflags", sf)
+        end)
+
+        ents.WaitForEntityByName("pvc4", function(ent)
+            local sf = bit.bor(4, 8, 128)
+            ent:SetKeyValue("spawnflags", sf)
+        end)
+
+        ents.WaitForEntityByName("pvc5", function(ent)
+            local sf = bit.bor(4, 8, 128)
+            ent:SetKeyValue("spawnflags", sf)
+        end)
     else
         -- The default spawn gets players stuck.
         for _, v in pairs(ents.FindByClass("info_player_start")) do

--- a/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_04.lua
+++ b/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_04.lua
@@ -30,6 +30,12 @@ MAPSCRIPT.EntityFilterByName = {
     ["vort_shaft_blocker_1"] = true,
     ["plank_2_kill_trigger"] = true,
     ["plank_2_break_trigger"] = true,
+    ["guardcaveentry_block_player"] = true,
+    ["maze_bridge_clip"] = true,
+    ["grub_tunnel_1_playerblock"] = true,
+    ["grub_tunnel_2_playerblock"] = true,
+    ["guard_leap_3_playerblock"] = true,
+    ["guard_exit_playerclip"] = true
 }
 
 MAPSCRIPT.GlobalStates = {
@@ -104,6 +110,12 @@ function MAPSCRIPT:PostInit()
         ent:ResizeTriggerBox(Vector(-10, -40, -40), Vector(40, 40, 40))
         ent:SetKeyValue("teamwait", "1")
     end)
+
+    -- TODO:
+    -- Throughout the map there are some trigger_multiple entities that are being fired when player is in/out of crawl spaces.
+    -- It handles some player clips and the antlion guard NPC.
+    -- To top it all off, they are as a group of brushes with "complex" geometry. 
+    -- >>:( 
 
 end
 

--- a/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_06a.lua
+++ b/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_06a.lua
@@ -34,17 +34,32 @@ MAPSCRIPT.EntityFilterByName = {
     ["global_newgame_template_base_items"] = true,
     ["global_newgame_template_local_items"] = true,
     ["playerclip_powerroom"] = true,
+    ["playerclip_elevator"] = true,
+    ["teleport_jeep"] = true,
+    ["fade_start"] = true,
 }
 
 MAPSCRIPT.GlobalStates = {
 }
 
 MAPSCRIPT.Checkpoints = {
+    {
+        Pos = Vector(-1763.0, -9607.42, -1536),
+        Ang = Angle(0, 109, 0),
+        RenderPos = Vector(-1814.464355, -9021.433594, -1556.093262),
+        Trigger = {
+            Pos = Vector(-1312.065430, -9076.086914, -1576.651123),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 100)
+        },
+        Vehicle = {
+            Pos = Vector(-1724.15, -9506.5, -1533),
+            Ang = Angle(0, 40, 0),
+        },
+    },
 }
 
 function MAPSCRIPT:PostInit()
-    print("-- Incomplete mapscript --")
-
     -- Power room checkpoint
     local cp1_powerroom = GAMEMODE:CreateCheckpoint(Vector(-3330, -9731, -1519))
     ents.WaitForEntityByName("trigger_alyx_standby", function(ent)

--- a/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_07.lua
+++ b/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_07.lua
@@ -48,6 +48,7 @@ MAPSCRIPT.EntityFilterByName = {
     ["global_newgame_template_ammo"] = true,
     ["global_newgame_template_local_items"] = true,
     ["template_barn_vclip"] = true, -- Has a template that doesn't exist.
+    ["barn_hole_playerclip"] = true
 }
 
 MAPSCRIPT.GlobalStates = {

--- a/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_10.lua
+++ b/gamemode/gametypes/hl2ep2/mapscripts/ep2_outland_10.lua
@@ -44,6 +44,48 @@ MAPSCRIPT.Checkpoints = {
 
 function MAPSCRIPT:PostInit()
     print("-- Incomplete mapscript --")
+
+    -- Find trigger_once at 3448 -384 0.05
+    local triggerAmbush = ents.FindByPos(Vector(3448.000000, -384.000000, 0.050000), "trigger_once")
+    if #triggerAmbush == 0 then
+        ErrorNoHalt("Warning: Could not find trigger_once at 3448 -384 0.05")
+    else
+        triggerAmbush = triggerAmbush[1]
+        triggerAmbush:SetKeyValue("targetname", "lambda_trigger_ambush")
+        triggerAmbush:Input("Disable")
+        triggerAmbush:SetupTrigger(
+            Vector(3398, -610, -133),
+            Angle(0, 0, 0),
+            Vector(-900, -430, -100),
+            Vector(250, 350, 300)
+        )
+        print("Disabling")
+    end
+
+    -- Area for players to wait for the real ambush.
+    local actualAmbushTrigger = ents.Create("trigger_once")
+    actualAmbushTrigger:SetupTrigger(
+        Vector(3398, -610, -133),
+        Angle(0, 0, 0),
+        Vector(-900, -430, -100),
+        Vector(250, 350, 300)
+    )
+    actualAmbushTrigger:SetKeyValue("StartDisabled", "1")
+    actualAmbushTrigger:SetKeyValue("targetname", "lambda_trigger_ambush_wait")
+    actualAmbushTrigger:SetKeyValue("teamwait", "1")
+    actualAmbushTrigger:Fire("AddOutput", "OnTrigger lambda_trigger_ambush,Enable,,0,-1")
+
+    -- Create trigger that starts the first combine shield.
+    local triggerStartShield = ents.Create("trigger_once")
+    triggerStartShield:SetupTrigger(
+        Vector(3448.000000, -384.000000, 0.050000),
+        Angle(0, 0, 0),
+        Vector(-130, -100, -100),
+        Vector(200, 100, 100)
+    )
+    triggerStartShield:Fire("AddOutput", "OnTrigger relay_combineshieldwall1_on,Trigger,,0,-1")
+    triggerStartShield:Fire("AddOutput", "OnTrigger combine_generator_idleon_wav,PlaySound,,0,-1")
+    triggerStartShield:Fire("AddOutput", "OnTrigger lambda_trigger_ambush_wait,Enable,,0,-1")
 end
 
 function MAPSCRIPT:OnJalopyCreated(jalopy)

--- a/gamemode/sh_ents_extend.lua
+++ b/gamemode/sh_ents_extend.lua
@@ -198,6 +198,10 @@ function ents.FindByPos(pos, class, name)
     local found = ents.FindInBox(pos - tolerance, pos + tolerance)
     local res = {}
     for _, v in pairs(found) do
+        local p2 = v:GetPos()
+        if pos:IsEqualTol(p2, 0.001) == false then
+            continue
+        end
         if class ~= nil and name ~= nil then
             if v:GetClass() == class and v:GetName() == name then
                 table.insert(res, v)


### PR DESCRIPTION
### outland_01 ###
- [ ]  Come up with a solution to the Alyx hunter scene. I wouldn't complicate it by making everyone go inside that crawl space under the building to start that scene. Just make sure that everyone is inside the building then enable the button to activate stuff.


### outland_04 ###
- [ ] Throughout the map there are some trigger_multiple entities that are being fired when player is in/out of crawl spaces. It handles some player clips and the antlion guard NPC and to top it all off, they are as a group of brushes with "complex" geometry. 


### outland_06 ###
- [ ] After obtaining the Jalopy and driving off that bridge, Alyx will sit in and not interact with the Vortigaunt anymore thus not opening the gate to continue to the next map.


### outland_07 ###
- [ ] When the hunter encounter is finished, Alyx will refuse to enter anyone's car.


### outland_08 ###
- [ ] Before entering the last part of the map where the heli battle takes place, the wooden gate doesn't break by driving through it.
